### PR TITLE
Fix syntax error in script

### DIFF
--- a/extras/theme/static/js/scroll.js
+++ b/extras/theme/static/js/scroll.js
@@ -39,7 +39,7 @@ $('.nav-toggle').click(real_nav);
 
 /*
 $(document).keydown(function(e){
-    /* console.log(e.keyCode) */
+    // console.log(e.keyCode)
     if (e.keyCode == 83) { 
        toggle_nav();
     }


### PR DESCRIPTION
The multiline comment inside the other multiline comment was causing a syntax error.